### PR TITLE
fix: patch transitive bl vulnerability via override

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -82,6 +82,7 @@
 - [x] Pin release publish action – Replace `softprops/action-gh-release@v2` with a pinned commit SHA in `release.yml`.
 - [x] Clean up CodeQL default languages – In GitHub settings, disable `Ruby` and `Swift` for default setup (or switch to advanced setup with custom build commands) to clear current default-setup tool errors.
 - [x] Stabilize platform CI jobs on main/tags – Fix remaining desktop/icon packaging and Godot export-template path issues so non-PR platform workflow can go green.
+- [x] Patch transitive `bl` vulnerability path – Force `bl@1.2.3` via root `overrides` so `swf-extract -> png-stream -> bl` no longer pulls vulnerable `bl@0.9.5`.
 
 ## Low priority
 - [x] Gamepad support – Map common controllers to the input layer (Xbox/PS/Switch layouts) and document the mappings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,34 +392,48 @@
       }
     },
     "node_modules/bl": {
-      "version": "0.9.5",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha512-njlCs8XLBIK7LCChTWfzWuIAxkpmmLXcL7/igCofFT1B039Sz0IPnAmosN5QaO22lU4qr8LcUz2ojUlE6pLkRQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readable-stream": "~1.0.26"
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/bl/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/bl/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+    "node_modules/bl/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/bplist-parser": {
       "version": "0.3.2",
@@ -699,9 +713,9 @@
       }
     },
     "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -954,6 +968,13 @@
         "buffer-equal": "^0.0.1",
         "pixel-stream": "^1.0.3"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "@capacitor/ios": "^6.1.0",
     "lodash": "^4.17.23",
     "swf-extract": "^1.1.0"
+  },
+  "overrides": {
+    "bl": "1.2.3"
   }
 }


### PR DESCRIPTION
**Summary**
This PR fixes the open Dependabot vulnerability caused by transitive `bl@0.9.5` by forcing a patched `bl` version at the workspace root. It keeps the existing asset-extraction workflow intact and updates the backlog with the completed item.

**Changes**
- Added root `npm` override for `bl` in `package.json`.
- Regenerated `package-lock.json` so `swf-extract -> png-stream -> bl` resolves to `bl@1.2.3`.
- Updated backlog with a completed follow-up item for this transitive dependency fix in `TODO.md`.

**Testing**
- `npm ci`
- `npm audit`
- `npm ls bl --all`
- `node scripts/extract_original_assets.mjs --swf assets/original/tanks.swf --out output/extract-test --force`

**Risk & Impact**
- Low to medium: this is a transitive dependency override outside the original semver range (`png-stream` expected `bl@0.9.x`).
- Mitigation: extraction script was executed successfully after the lock update.
- No runtime impact on app clients; scope is tooling/dependency graph.

**Related TODO items**
- [x] Patch transitive `bl` vulnerability path – Force `bl@1.2.3` via root `overrides` so `swf-extract -> png-stream -> bl` no longer pulls vulnerable `bl@0.9.5`.
