### PR TITLE
fix: unblock tag release artifact jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,10 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          mkdir -p ../../release-out
+          OUT_DIR="${GITHUB_WORKSPACE}/release-out"
+          mkdir -p "$OUT_DIR"
           cd dist
-          zip -r "../../release-out/Tanks-${TAG}-web-dist.zip" .
+          zip -r "${OUT_DIR}/Tanks-${TAG}-web-dist.zip" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -108,9 +109,10 @@ jobs:
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
-          mkdir -p ../../release-out
+          OUT_DIR="${GITHUB_WORKSPACE}/release-out"
+          mkdir -p "$OUT_DIR"
           cd dist
-          zip -r "../../release-out/Tanks-${TAG}-remake-web-dist.zip" .
+          zip -r "${OUT_DIR}/Tanks-${TAG}-remake-web-dist.zip" .
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -133,6 +135,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Prepare export templates
+        shell: bash
         run: |
           set -euo pipefail
           DST="${HOME}/.local/share/godot/export_templates/${GODOT_VERSION}.stable"
@@ -157,6 +160,7 @@ jobs:
           fi
 
       - name: Export (Windows/Linux/macOS)
+        shell: bash
         run: |
           set -euo pipefail
           WORKSPACE="${GITHUB_WORKSPACE:-$(pwd)}"


### PR DESCRIPTION
## Summary
Fixes failures in tag release workflow so assets can be produced for web/remake-web/Godot.

## Changes
- fix web/remake-web zip output paths to use ${GITHUB_WORKSPACE}/release-out
- force Bash shell for Godot template/export steps in container job

## Testing
- reviewed failing run logs for v0.1.0 run 21871943314 and patched exact failing steps
- no runtime app code changes

## Risk & Impact
- low; workflow-only changes

## Related TODO
- release stabilization follow-up from closeout