### PR TITLE
fix: resolve open code-scanning alerts (Sonar S8264, CodeQL unused var)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
   verify:
     name: Verify tag/version sync
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,6 +47,8 @@ jobs:
     name: Build (web dist zip)
     runs-on: ubuntu-latest
     needs: verify
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/web
@@ -85,6 +89,8 @@ jobs:
     name: Build (remake web dist zip)
     runs-on: ubuntu-latest
     needs: verify
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/remake-web
@@ -125,6 +131,8 @@ jobs:
     name: Build (remake Godot desktop exports)
     runs-on: ubuntu-latest
     needs: verify
+    permissions:
+      contents: read
     container:
       image: barichello/godot-ci:4.2.2
     env:
@@ -183,6 +191,8 @@ jobs:
     name: Build (Windows installer + portable zip)
     runs-on: windows-latest
     needs: verify
+    permissions:
+      contents: read
     env:
       WINDOWS_CERT_PFX_BASE64: ${{ secrets.WINDOWS_CERT_PFX_BASE64 }}
       WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
@@ -260,6 +270,8 @@ jobs:
     name: Build (Android debug APK)
     runs-on: ubuntu-latest
     needs: verify
+    permissions:
+      contents: read
     env:
       ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
       ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
@@ -361,6 +373,8 @@ jobs:
     name: Build (iOS simulator .app zip)
     runs-on: macos-latest
     needs: verify
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -157,7 +157,6 @@ def main() -> int:
                 status = "fail"
                 break
             except Exception as exc:  # pragma: no cover - network/runtime surface
-                last_exc = exc
                 findings.append(f"Codacy API request failed: {exc}")
                 status = "fail"
                 break

--- a/scripts/quality/check_codacy_zero.py
+++ b/scripts/quality/check_codacy_zero.py
@@ -11,31 +11,50 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-_SCRIPT_DIR = Path(__file__).resolve().parent
-_HELPER_ROOT = _SCRIPT_DIR if (_SCRIPT_DIR / "security_helpers.py").exists() else _SCRIPT_DIR.parent
-if str(_HELPER_ROOT) not in sys.path:
-    sys.path.insert(0, str(_HELPER_ROOT))
-
 from security_helpers import normalize_https_url
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_HELPER_ROOT = (
+    _SCRIPT_DIR
+    if (_SCRIPT_DIR / "security_helpers.py").exists()
+    else _SCRIPT_DIR.parent
+)
+if str(_HELPER_ROOT) not in sys.path:
+    sys.path.insert(0, str(_HELPER_ROOT))
 
 TOTAL_KEYS = {"total", "totalItems", "total_items", "count", "hits", "open_issues"}
 CODACY_API_BASE = "https://api.codacy.com"
 
 
 def _parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Assert Codacy has zero total open issues.")
-    parser.add_argument("--provider", default="gh", help="Organization provider, for example gh")
+    parser = argparse.ArgumentParser(
+        description="Assert Codacy has zero total open issues."
+    )
+    parser.add_argument(
+        "--provider", default="gh", help="Organization provider, for example gh"
+    )
     parser.add_argument("--owner", required=True, help="Repository owner")
     parser.add_argument("--repo", required=True, help="Repository name")
-    parser.add_argument("--token", default="", help="Codacy API token (falls back to CODACY_API_TOKEN env)")
-    parser.add_argument("--out-json", default="codacy-zero/codacy.json", help="Output JSON path")
-    parser.add_argument("--out-md", default="codacy-zero/codacy.md", help="Output markdown path")
+    parser.add_argument(
+        "--token",
+        default="",
+        help="Codacy API token (falls back to CODACY_API_TOKEN env)",
+    )
+    parser.add_argument(
+        "--out-json", default="codacy-zero/codacy.json", help="Output JSON path"
+    )
+    parser.add_argument(
+        "--out-md", default="codacy-zero/codacy.md", help="Output markdown path"
+    )
     return parser.parse_args()
 
 
-def _request_json(url: str, token: str, *, method: str = "GET", data: dict[str, Any] | None = None) -> dict[str, Any]:
-    safe_url = normalize_https_url(url, allowed_host_suffixes={"codacy.com"}).rstrip("/")
+def _request_json(
+    url: str, token: str, *, method: str = "GET", data: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    safe_url = normalize_https_url(url, allowed_host_suffixes={"codacy.com"}).rstrip(
+        "/"
+    )
     body = None
     headers = {
         "Accept": "application/json",
@@ -119,7 +138,9 @@ def main() -> int:
 
     args = _parse_args()
     token = (args.token or os.environ.get("CODACY_API_TOKEN", "")).strip()
-    api_base = normalize_https_url(CODACY_API_BASE, allowed_hosts={"api.codacy.com"}).rstrip("/")
+    api_base = normalize_https_url(
+        CODACY_API_BASE, allowed_hosts={"api.codacy.com"}
+    ).rstrip("/")
     owner = urllib.parse.quote(args.owner.strip(), safe="")
     repo = urllib.parse.quote(args.repo.strip(), safe="")
 
@@ -144,9 +165,13 @@ def main() -> int:
                 payload = _request_json(url, token, method="POST", data={})
                 open_issues = extract_total_open(payload)
                 if open_issues is None:
-                    findings.append("Codacy response did not include a parseable total issue count.")
+                    findings.append(
+                        "Codacy response did not include a parseable total issue count."
+                    )
                 elif open_issues != 0:
-                    findings.append(f"Codacy reports {open_issues} open issues (expected 0).")
+                    findings.append(
+                        f"Codacy reports {open_issues} open issues (expected 0)."
+                    )
                 status = "pass" if not findings else "fail"
                 break
             except urllib.error.HTTPError as exc:
@@ -187,7 +212,9 @@ def main() -> int:
 
     out_json.parent.mkdir(parents=True, exist_ok=True)
     out_md.parent.mkdir(parents=True, exist_ok=True)
-    out_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    out_json.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
     out_md.write_text(_render_md(payload), encoding="utf-8")
     print(out_md.read_text(encoding="utf-8"), end="")
     return 0 if status == "pass" else 1


### PR DESCRIPTION
## **User description**
## Summary

Resolves the two open code-scanning alerts with real, behavior-preserving fixes (no dismissals).

### Alert #33 — Sonar \`githubactions:S8264\` (release.yml)
"Read permissions should be defined at the job level." Added explicit \`permissions: contents: read\` to the 7 build/verify jobs that lacked job-level permissions. This mirrors the pattern already accepted on this repo's other workflows (\`ci.yml\` #32, \`ci-fast.yml\` #31, \`quality-zero-gate.yml\` #34 are all "fixed" with the same workflow-level + job-level read approach).

- The \`publish\` job already declares \`contents: write\` (needed by \`softprops/action-gh-release\`) — unchanged.
- All other jobs only checkout / build / \`upload-artifact\` (which does not require \`contents: write\`) and read code-signing \`secrets\` (orthogonal to \`permissions:\`), so \`read\` is correct.

### Alert #28 — CodeQL \`py/unused-local-variable\` (scripts/quality/check_codacy_zero.py)
Removed the dead \`last_exc = exc\` assignment in the generic \`except Exception\` handler. That branch unconditionally \`break\`s, so the assigned value can never reach the \`for/else\` clause's \`if last_exc is not None\` read — it was provably unused. The HTTP-error branch (line ~153, which uses \`continue\`) keeps its \`last_exc\` assignment.

## Verification
- \`actionlint .github/workflows/release.yml\` → clean (exit 0)
- \`python -m py_compile scripts/quality/check_codacy_zero.py\` → OK
- Ran \`check_codacy_zero.py\` end-to-end against the live Codacy API → valid JSON/MD output, no runtime error
- YAML parse confirms all 8 jobs now carry explicit job-level \`permissions\`

Note: the Sonar/CodeQL dashboard transitions these alerts to "fixed" on the next scan after merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves Sonar S8264 and CodeQL unused-variable alerts with behavior-preserving fixes. Adds job-level permissions in the release workflow and cleans up an unused variable and formatting in the Codacy check script.

- **Bug Fixes**
  - .github/workflows/release.yml: add `permissions: contents: read` to 7 build/verify jobs to satisfy Sonar `githubactions:S8264`.
  - scripts/quality/check_codacy_zero.py: remove unused `last_exc` assignment to fix CodeQL `py/unused-local-variable`; apply formatting (no behavior change).

<sup>Written for commit ff39d291c917ffb736c973ba8d32a83bea70edcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/TanksFlashMobile/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Keep release checks and Codacy issue checks working without changing build results

### What Changed
- Added explicit read access to each release build job so the release workflow can run without permission warnings.
- Removed a dead assignment in the Codacy zero-check script, which clears a code-scanning warning without changing its output.

### Impact
`✅ Fewer release workflow permission alerts`
`✅ Cleaner code-scanning results`
`✅ No change to release artifacts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration for enhanced security across build jobs.
  * Refactored code quality check script for improved maintainability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->