### PR TITLE
chore: remove DeepScan provider entry

### DIFF
--- a/docs/quality/QUALITY_ZERO_GATES.md
+++ b/docs/quality/QUALITY_ZERO_GATES.md
@@ -3,7 +3,7 @@
 This repository is configured for strict quality enforcement:
 
 - Coverage target: 100% (project + patch)
-- Mandatory zero-open findings: Sonar, Codacy, Semgrep, Sentry, DeepScan
+- Mandatory zero-open findings: Sonar, Codacy, Semgrep, Sentry
 - Fail-closed secrets preflight
 - Aggregated required-context assertion via `Quality Zero Gate`
 


### PR DESCRIPTION
Removes the retired DeepScan provider from the mandatory zero-open-findings list in docs/quality/QUALITY_ZERO_GATES.md. Docs-only cleanup of a retired provider; no CI/coverage impact.