### PR TITLE
DO NOT MERGE: A/B probe - reusable-quality pin @v1 -> @main

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,3 +1,4 @@
+# DO NOT MERGE - evidence branch for the quality-zero-platform v1 tag-move decision (paired A/B; sibling branch differs only in the reusable pin).
 name: quality
 
 # Lean 6-gate quality gate (ADDITIVE — see the lean-gate charter, decided
@@ -27,4 +28,4 @@ permissions:
 
 jobs:
   quality:
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@v1
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-quality.yml@main


### PR DESCRIPTION
DO NOT MERGE: A/B probe arm (pin @v1 -> @main)

Evidence artifact for the "is it safe to move the v1 tag in
quality-zero-platform" decision. Repins reusable-quality.yml from @v1 to @main
so CI here executes the 20-commits-ahead template that moving the tag would
publish to every consumer.

Carries the same single comment line as the control branch, so control vs probe
differ by exactly one variable: the pin.

Not for merge. Close when the tag decision is recorded.
